### PR TITLE
Adjust UI to deal with missing index

### DIFF
--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -9,22 +9,22 @@
 <?import javafx.scene.layout.VBox?>
 
 <HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1"
-      prefWidth="200" maxWidth="Infinity" minWidth="0">
-    <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
+      maxWidth="Infinity" minWidth="0">
+    <VBox alignment="CENTER_LEFT" minHeight="115" GridPane.columnIndex="0">
       <padding>
-        <Insets top="5" right="5" bottom="5" left="15" />
+        <Insets top="5" right="10" bottom="5" left="15" />
       </padding>
       <HBox spacing="5" alignment="CENTER_LEFT">
         <Label fx:id="id" styleClass="cell_big_label">
-          <maxWidth>
+          <minWidth>
             <Region fx:constant="USE_PREF_SIZE" />
-          </maxWidth>
+          </minWidth>
         </Label>
-        <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
+        <Label fx:id="name" text="\$first" styleClass="cell_big_label" wrapText="true"/>
       </HBox>
 
       <!-- Tags -->
-      <FlowPane fx:id="tags" />
+      <FlowPane fx:id="tags" vgap="3"/>
 
       <!-- Owned properties line -->
       <HBox spacing="5" alignment="CENTER_LEFT" HBox.hgrow="ALWAYS">

--- a/src/main/resources/view/PropertyListCard.fxml
+++ b/src/main/resources/view/PropertyListCard.fxml
@@ -9,15 +9,15 @@
 
 <HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1"
       prefWidth="200" maxWidth="Infinity" minWidth="0">
-    <VBox alignment="CENTER_LEFT" minHeight="100" GridPane.columnIndex="0">
+    <VBox alignment="CENTER_LEFT" minHeight="85" GridPane.columnIndex="0">
       <padding>
-        <Insets top="5" right="5" bottom="5" left="15" />
+        <Insets top="5" right="10" bottom="5" left="15" />
       </padding>
       <HBox spacing="5" alignment="CENTER_LEFT" maxWidth="Infinity">
         <Label fx:id="id" styleClass="cell_big_label">
-          <maxWidth>
+          <minWidth>
             <Region fx:constant="USE_PREF_SIZE" />
-          </maxWidth>
+          </minWidth>
         </Label>
         <Label fx:id="propertyName" text="\$propertyName" styleClass="cell_big_label" />
       </HBox>


### PR DESCRIPTION
Fixes #293 

- Includes wrapping options of tags, interested and owned properties
- Long names will also be dealt with in a future PR (Character restrictions)
- Scroll Bar will be generated for windows which are too small to fit the content.

## Screenshots
<img width="1113" height="937" alt="image" src="https://github.com/user-attachments/assets/a9855390-7996-49e5-9f50-95d9aea4a00a" />
<img width="551" height="212" alt="image" src="https://github.com/user-attachments/assets/c54f699f-333f-4da9-894a-574ea70d04f2" />
